### PR TITLE
Fix Mysql2psql: Conversion failed: packet is not EOF

### DIFF
--- a/lib/mysql-pr/packet.rb
+++ b/lib/mysql-pr/packet.rb
@@ -1,3 +1,5 @@
+#encoding: ascii-8bit
+
 class MysqlPR
   class Packet
     # convert Numeric to LengthCodedBinary


### PR DESCRIPTION
This error happens with Ruby 2.x